### PR TITLE
new init.d script to allow reboot again

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,23 @@ I use and will use this software. But in the end - if anything happens to your h
     git clone https://github.com/nthx/odroid-xu3-fan-control.git
     cd odroid-xu3-fan-control
     sudo ./odroid-xu3-fan-control.sh
-    
 
 ## Installation
 
 To make it start when system boots:
 
-    sudo ln -s ~/odroid-xu3-fan-control/odroid-xu3-fan-control.sh /etc/init.d/
-    sudo update-rc.d odroid-xu3-fan-control.sh defaults
-    
-(although, currently it causes `sudo poweroff` to block powering down :-( )
+edit odroid-fan-controller and add the path of the odroid-xu3-fan-control.sh script (full-pathname), then do the following to add it
+to the runlevels
+
+    sudo ln -s ~/odroid-xu3-fan-control/odroid-fan-controller /etc/init.d/
+    sudo update-rc.d odroid-fan-controller defaults
+
+you can also use the following to start the controller
+
+    sudo /etc/init.d/odroid-fan-controller start
+
+or
+
+    sudo /etc/init.d/odroid-fan-controller stop
+
+to stop the controller

--- a/odroid-fan-controller
+++ b/odroid-fan-controller
@@ -1,0 +1,94 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          odroid-fan-controller
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start daemon at boot time
+# Description:       Enable service provided by daemon.
+### END INIT INFO
+
+dir=""
+user="root"
+cmd="./odroid-xu3-fan-control.sh"
+
+name=`basename $0`
+pid_file="/var/run/$name.pid"
+stdout_log="/var/log/$name.log"
+stderr_log="/var/log/$name.err"
+
+get_pid() {
+    cat "$pid_file"
+}
+
+is_running() {
+    [ -f "$pid_file" ] && ps `get_pid` > /dev/null 2>&1
+}
+
+case "$1" in
+    start)
+    if is_running; then
+        echo "Already started"
+    else
+        echo "Starting $name"
+        cd "$dir"
+        sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+        echo $! > "$pid_file"
+        if ! is_running; then
+            echo "Unable to start, see $stdout_log and $stderr_log"
+            exit 1
+        fi
+    fi
+    ;;
+    stop)
+    if is_running; then
+        echo -n "Stopping $name.."
+        kill `get_pid`
+        for i in {1..10}
+        do
+            if ! is_running; then
+                break
+            fi
+
+            echo -n "."
+            sleep 1
+        done
+        echo
+
+        if is_running; then
+            echo "Not stopped; may still be shutting down or shutdown may have failed"
+            exit 1
+        else
+            echo "Stopped"
+            if [ -f "$pid_file" ]; then
+                rm "$pid_file"
+            fi
+        fi
+    else
+        echo "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if is_running; then
+        echo "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    if is_running; then
+        echo "Running"
+    else
+        echo "Stopped"
+        exit 1
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
The new init.d script supplies the start, stop, restart and status commands which are needed for a
init.d script. If this script is used it won't block the system from a restart.
